### PR TITLE
Only go to sleep unless the machine is sleeping already

### DIFF
--- a/noclamshell
+++ b/noclamshell
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-CLAMSHELL=$(ioreg -r -k AppleClamshellState | grep AppleClamshellState | grep Yes)
-FLAG_FILE=$TMPDIR/noclamshell.lid.closed.and.sleeping
-
-if [ "$CLAMSHELL" ]; then
-  if [[ ! -f $FLAG_FILE ]]; then
-    touch $FLAG_FILE
-    pmset sleepnow
+LID_CLOSED=$(ioreg -r -k AppleClamshellState | grep AppleClamshellState | grep Yes)
+if [ "$LID_CLOSED" ]; then
+  EXTERNAL_DISPLAY_CONNECTED=$(pmset -g powerstate | grep AppleDisplay | grep USEABLE)
+  if [ "$EXTERNAL_DISPLAY_CONNECTED" ]; then
+    AWAKE=$(pmset -g powerstate | grep IODisplayWrangler | grep USEABLE)
+    if [ "$AWAKE" ]; then
+      pmset sleepnow
+    fi
   fi
-else
-  rm -f $FLAG_FILE
 fi


### PR DESCRIPTION
The previous version of the script was attempting to put the machine to sleep even if it was sleeping already. This resulted in the machine not waking up again until a cold reboot under some circumstances.
macOS wakes up periodically to do some work, and if it happened that the script was run by the service during this period of time, this had this undesired side effect.