### PR TITLE
Add check for DCPDPServiceProxy

### DIFF
--- a/noclamshell
+++ b/noclamshell
@@ -10,8 +10,10 @@ if [ "$LID_CLOSED" ]; then
     fi
   fi
 
-  NUM_DEVICE_PROXY=$(pmset -g powerstate | grep DCPDPDeviceProxy | wc -l)
-  ARM_AWAKE=$((NUM_DEVICE_PROXY < 4))
+  NUM_DEVICE_PROXY=$(pmset -g powerstate | grep -c DCPDPDeviceProxy)
+  NUM_SERVICE_PROXY=$(pmset -g powerstate | grep -c DCPDPServiceProxy)
+  ARM_AWAKE=$(( 0 < NUM_DEVICE_PROXY && NUM_DEVICE_PROXY < 4 ||
+        0 < NUM_SERVICE_PROXY && NUM_SERVICE_PROXY < 4 ))
   if [ "$ARM_AWAKE" ]; then
     pmset sleepnow
   fi


### PR DESCRIPTION
fixes #31. The old check is left in for backward compatibility, since I don't know if people sill depend on it.

To prevent the check from always passing when either of the two counts are 0 (which it is on my machine at least), I constrained it to check for >0 as well.